### PR TITLE
chore: add `cooldown` to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 30
+    # Wait 14 days before updating to help circumvent supply chain attacks
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "maven"
     directory: "/"
@@ -14,3 +17,6 @@ updates:
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
         update-types: [ "version-update:semver-major" ]
+    # Wait 14 days before updating to help circumvent supply chain attacks
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
This PR will add a cooldown for 14 days to dependabot, to circumvent supply chain attacks.